### PR TITLE
[WIP] Refactor log rendering

### DIFF
--- a/app/Resources/translations/messages.en.xlf
+++ b/app/Resources/translations/messages.en.xlf
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" target-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>irc.joined_channel</source>
+                <target>%actor% (%actor_hostname%) joined the channel</target>
+                <note>Used in IRC logs, example: "@Kashike joined the channel"</note>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>irc.kicked_by</source>
+                <target>%recipient_actor% was kicked by %actor% (%kick_message%)</target>
+                <note>Used in IRC logs, example: "@lol768 was kicked by @Kashike (hello)"</note>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>irc.set_mode</source>
+                <target>%actor% sets mode %mode%</target>
+                <note>Used in IRC logs, example: "@Kashike sets mode +b *!*@test.com". Please note that %mode% includes the entire last part "+b *!*@test.com".</note>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>irc.known_as</source>
+                <target>%original_actor% is now known as %new_actor%</target>
+                <note>Used in IRC logs, example: "@drtshock is now known as @Trent"</note>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>irc.left_channel</source>
+                <target>%actor% (%actor_hostname%) left the channel</target>
+                <note>Used in IRC logs, example: "lol768 (lol768!lol7681@bnc.lol768.com) left the channel"</note>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>irc.has_quit</source>
+                <target>%actor% (%actor_hostname%) has quit (%quit_message%)</target>
+                <note>Used in IRC logs, example: "lol768 (lol768!lol7681@bnc.lol768.com) has quit (I hate you all)"</note>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>irc.topic_is</source>
+                <target>Topic is: %topic%</target>
+                <note>Used in IRC logs, example: "lol768 (lol768!lol7681@bnc.lol768.com) left the channel"</note>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>irc.has_changed_topic_to</source>
+                <target>%actor% has changed the topic to: %topic%</target>
+                <note>Used in IRC logs, example: "@lol768 has changed the topic to: testing123</note>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>irc.server</source>
+                <target>Server</target>
+                <note>Used in IRC logs where the server is responsible (this becomes %actor%).</note>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -4,7 +4,7 @@ imports:
 
 framework:
     #esi:             ~
-    #translator:      { fallback: "%locale%" }
+    translator:      { fallback: "%locale%" }
     secret:          "%secret%"
     router:
         resource: "%kernel.root_dir%/config/routing.yml"

--- a/src/Korobi/WebBundle/Controller/BaseController.php
+++ b/src/Korobi/WebBundle/Controller/BaseController.php
@@ -4,6 +4,7 @@ namespace Korobi\WebBundle\Controller;
 
 use Korobi\WebBundle\Document\Channel;
 use Korobi\WebBundle\Document\Network;
+use Korobi\WebBundle\IrcLogs\RenderManager;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
@@ -92,7 +93,7 @@ abstract class BaseController extends Controller {
         $dbChannel = $this->get('doctrine_mongodb')
             ->getManager()
             ->getRepository('KorobiWebBundle:Channel')
-            ->findByChannel($network, self::transformChannelName(preg_quote($channel), true))
+            ->findByChannel($network, self::transformChannelName($channel, true))
             ->toArray(false);
 
         // make sure we actually have a channel
@@ -111,5 +112,12 @@ abstract class BaseController extends Controller {
      */
     protected function getLogger() {
         return $this->get('logger');
+    }
+
+    /**
+     * @return RenderManager
+     */
+    protected function getRenderManager() {
+        return $this->get("korobi.irc.render_manager");
     }
 }

--- a/src/Korobi/WebBundle/Controller/Generic/HomeController.php
+++ b/src/Korobi/WebBundle/Controller/Generic/HomeController.php
@@ -55,7 +55,7 @@ class HomeController extends BaseController {
             'now' => time(),
             'channels' => $dbChannels,
             'networks' => $networks,
-            'messages' => array_map([ChatTransformer::class, 'transformMessage'], $messages),
+            'messages' => $this->getRenderManager()->renderLogs($messages, ["message"]),
         ]);
     }
 

--- a/src/Korobi/WebBundle/Deployment/DeploymentInfo.php
+++ b/src/Korobi/WebBundle/Deployment/DeploymentInfo.php
@@ -4,6 +4,7 @@ namespace Korobi\WebBundle\Deployment;
 
 use Korobi\WebBundle\Document\Revision;
 use Korobi\WebBundle\Document\User;
+use Korobi\WebBundle\Util\AkioMessageBuilder;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authorization\AuthorizationChecker;
 
@@ -47,6 +48,11 @@ class DeploymentInfo {
      * @var array Array of statuses
      */
     private $status;
+
+    /**
+     * @var AkioMessageBuilder[] Holds a queue of messages to send all at once.
+     */
+    protected $messageQueue = [];
 
     /**
      * @param $request Request
@@ -115,5 +121,19 @@ class DeploymentInfo {
     public function addStatus($status) {
         $this->status[] = $status;
         $this->revision->setStatuses($this->status);
+    }
+
+    /**
+     * @param AkioMessageBuilder $message The message to add.
+     */
+    public function addMessageToQueue(AkioMessageBuilder $message) {
+        $this->messageQueue[] = $message;
+    }
+
+    /**
+     * @return \Korobi\WebBundle\Util\AkioMessageBuilder[]
+     */
+    public function getAllMessagesInQueue() {
+        return $this->messageQueue;
     }
 }

--- a/src/Korobi/WebBundle/Deployment/Processor/BaseProcessor.php
+++ b/src/Korobi/WebBundle/Deployment/Processor/BaseProcessor.php
@@ -7,6 +7,7 @@ use Korobi\WebBundle\Deployment\DeploymentInfo;
 use Korobi\WebBundle\Deployment\DeploymentLogger;
 use Korobi\WebBundle\Deployment\DeploymentStatus;
 use Korobi\WebBundle\Util\Akio;
+use Korobi\WebBundle\Util\AkioMessageBuilder;
 use Korobi\WebBundle\Util\GitInfo;
 
 /**
@@ -20,10 +21,12 @@ abstract class BaseProcessor implements DeploymentProcessorInterface {
      * @var DeploymentProcessorInterface
      */
     private $next;
+
     /**
      * @var DeploymentLogger
      */
     protected $logger;
+
     /**
      * @var Akio
      */
@@ -36,6 +39,11 @@ abstract class BaseProcessor implements DeploymentProcessorInterface {
      * @var DocumentManager
      */
     protected $dm;
+
+    /**
+     * @var AkioMessageBuilder[] Holds a queue of messages to send all at once.
+     */
+    protected $messageQueue = [];
 
     public function __construct(DeploymentLogger $logger, Akio $akio, DocumentManager $dm, GitInfo $gi) {
         $this->logger = $logger;

--- a/src/Korobi/WebBundle/Deployment/Processor/FinalizeDeployment.php
+++ b/src/Korobi/WebBundle/Deployment/Processor/FinalizeDeployment.php
@@ -4,6 +4,7 @@ namespace Korobi\WebBundle\Deployment\Processor;
 
 use Korobi\WebBundle\Deployment\DeploymentInfo;
 use Korobi\WebBundle\Deployment\DeploymentStatus;
+use Korobi\WebBundle\Util\AkioMessageBuilder;
 
 /**
  * Saves deployment results to the database.
@@ -15,7 +16,14 @@ class FinalizeDeployment extends BaseProcessor implements DeploymentProcessorInt
     public function handle(DeploymentInfo $info) {
         $this->dm->persist($info->getRevision());
         $this->dm->flush();
-        $this->akio->message()->text('Full details at https://dev.korobi.io/deploy/view/' . $info->getRevision()->getId() . '/')->send('deploy');
+        $info->addMessageToQueue($this->akio->message()->text('Full details at https://dev.korobi.io/deploy/view/' .
+            $info->getRevision()->getId() . '/'));
+
+        if ($info->getRevision()->getOldCommit() !== $info->getRevision()->getNewCommit()) {
+            foreach ($info->getAllMessagesInQueue() as $message) {
+                $message->send("deploy");
+            }
+        }
 
         return DeploymentStatus::OK;
     }

--- a/src/Korobi/WebBundle/Deployment/Processor/RunTests.php
+++ b/src/Korobi/WebBundle/Deployment/Processor/RunTests.php
@@ -25,7 +25,7 @@ class RunTests extends BaseProcessor implements DeploymentProcessorInterface {
         $testOutput = exec('phpunit', $execOutput);
         $parsed = (new TestOutputParser())->parseLine($testOutput);
 
-        $message = $this->akio->message()->green()->text($parsed['passed'] . ' tests passed.');
+        $message = $this->akio->message()->green()->text($parsed['passed'] . ' tests passed!');
 
         if ($parsed['incomplete'] > 0) {
             $message = $message->yellow()->text(' ' . $parsed['incomplete'] . ' skipped/incomplete tests.');
@@ -37,7 +37,7 @@ class RunTests extends BaseProcessor implements DeploymentProcessorInterface {
             $info->addStatus(DeploymentStatus::TESTS_FAILED);
         }
 
-        $message->send('deploy');
+        $info->addMessageToQueue($message);
 
         $info->getRevision()->setTestsOutput(implode("\n", $execOutput));
         $info->getRevision()->setTestsPassed($parsed['failures'] === 0);

--- a/src/Korobi/WebBundle/IrcLogs/RenderManager.php
+++ b/src/Korobi/WebBundle/IrcLogs/RenderManager.php
@@ -1,0 +1,103 @@
+<?php
+
+
+namespace Korobi\WebBundle\IrcLogs;
+
+use Korobi\WebBundle\Document\Chat;
+use Korobi\WebBundle\Exception\UnsupportedOperationException;
+use Korobi\WebBundle\Parser\LogParserInterface;
+
+/**
+ * Class RenderManager
+ *
+ * Try to provide a common class for controllers which
+ * want to render logs on a page.
+ *
+ * @package Korobi\WebBundle\IrcLogs
+ */
+class RenderManager {
+
+    /**
+     * @var LogParserInterface
+     */
+    private $logParser;
+
+    /**
+     * RenderManager constructor.
+     * @param LogParserInterface $logParser
+     */
+    public function __construct(LogParserInterface $logParser) {
+        $this->logParser = $logParser;
+    }
+
+    /**
+     * Returns an array of data arrays ready to be rendered by a twig macro.
+     *
+     * @param Chat[] $chats
+     * @param array $typeWhitelist Optional array of types to allow. Lowercase please!
+     * @return array Array of data after applying RenderManager::processChatDocument
+     * @see processChatDocument
+     */
+    public function renderLogs(array $chats, array $typeWhitelist=[]) {
+        $out = [];
+        $emptyWhitelist = count($typeWhitelist) == 0;
+
+        foreach ($chats as $chat) {
+            if ($chat->getNotice() && $chat->getNoticeTarget() !== 'NORMAL') { // Don't show vnotices/opnotices!
+                continue;
+            }
+
+            if ($emptyWhitelist || in_array(strtolower($chat->getType()), $typeWhitelist)) {
+                $out[] = $this->processChatDocument($chat);
+            }
+        }
+        return $out;
+    }
+
+    /**
+     * Gives an array of data for one chat document.
+     * @param Chat $chat A single chat document.
+     * @return array The array of data for the twig macro.
+     */
+    public function processChatDocument($chat) {
+        $nick = $this->logParser->getDisplayName($chat);
+        return [
+            'id'          => $chat->getId(), // MongoID of chat document
+            'timestamp'   => $chat->getDate()->getTimestamp(), // Unix timestamp integer of chat document
+            'type'        => strtolower($chat->getType()), // Lowercase type identifier (e.g. 'join' or 'action')
+            'role'        => $chat->getType() == 'MESSAGE' ? strtolower($chat->getActorPrefix()) : '', // @, + etc
+            'nickColour'  => $this->logParser->getColourForActor($chat), // Colour of nick (applies weechat algorithm)
+            'displayNick' => substr($nick, 0, RenderSettings::MAX_NICK_LENGTH + 1), // Chopped nick
+            'realNick'    => $nick, // Full nick
+            'nickTooLong' => strlen($nick) - RenderSettings::MAX_NICK_LENGTH > 1, // If the nick got chopped
+            'nick'        => $this->logParser->getActorName($chat), // TODO: Better naming - returns hostname/nick
+            'message'     => $this->getHtmlFragmentForChatMessage($chat), // HTML'd message
+        ];
+
+    }
+
+    /**
+     * @param Chat $chat The chat entry to pass off to the parser.
+     * @return string The HTML fragment for the given chat message.
+     * @throws UnsupportedOperationException If you try and parse an unsupported message type.
+     */
+    public function getHtmlFragmentForChatMessage(Chat $chat) {
+        $method = 'parse' . ucfirst(strtolower($chat->getType())); // produces e.g. "parseJoin"
+        try {
+            $method = $this->getReflectionLogParser()->getMethod($method);
+            return $method->invokeArgs($this->logParser, [$chat]);
+        } catch (\ReflectionException $ex) {
+            // we can't parse this type of message
+            throw new UnsupportedOperationException("The method $method caused a reflection exception: " . $ex->getMessage());
+        }
+    }
+
+    /**
+     * @return \ReflectionClass The log parser reflection class.
+     */
+    private function getReflectionLogParser() {
+        return new \ReflectionClass($this->logParser);
+    }
+
+
+}

--- a/src/Korobi/WebBundle/IrcLogs/RenderSettings.php
+++ b/src/Korobi/WebBundle/IrcLogs/RenderSettings.php
@@ -1,0 +1,18 @@
+<?php
+
+
+namespace Korobi\WebBundle\IrcLogs;
+
+/**
+ * Provides common global settings for @see RenderManager.
+ * @package Korobi\WebBundle\IrcLogs
+ */
+class RenderSettings {
+
+    const MAX_NICK_LENGTH = 10;
+    const JOIN_USER_PREFIX = '-->';
+    const PART_USER_PREFIX = '<--';
+    const ACTION_USER_PREFIX = '*';
+    const ACTION_SERVER_PREFIX = '--';
+    const ACTION_SERVER_COLOUR = '14';
+}

--- a/src/Korobi/WebBundle/Parser/LogParserInterface.php
+++ b/src/Korobi/WebBundle/Parser/LogParserInterface.php
@@ -1,0 +1,93 @@
+<?php
+namespace Korobi\WebBundle\Parser;
+
+use Korobi\WebBundle\Document\Chat;
+
+interface LogParserInterface {
+    
+    /**
+     * @param Chat $chat
+     * @return string
+     */
+    public function parseAction(Chat $chat);
+
+    /**
+     * @param Chat $chat
+     * @return string
+     */
+    public function parseJoin(Chat $chat);
+
+    /**
+     * @param Chat $chat
+     * @return string
+     */
+    public function parseKick(Chat $chat);
+
+    /**
+     * @param Chat $chat
+     * @return string
+     */
+    public function parseMessage(Chat $chat);
+
+    /**
+     * @param Chat $chat
+     * @return string
+     */
+    public function parseMode(Chat $chat);
+
+    /**
+     * @param Chat $chat
+     * @return string
+     */
+    public function parseNick(Chat $chat);
+
+    /**
+     * @param Chat $chat
+     * @return string
+     */
+    public function parsePart(Chat $chat);
+
+    /**
+     * @param Chat $chat
+     * @return string
+     */
+    public function parseQuit(Chat $chat);
+
+    /**
+     * @param Chat $chat
+     * @return string
+     */
+    public function parseTopic(Chat $chat);
+
+    /**
+     * @param Chat $chat
+     * @return string
+     */
+    public function getColourForActor(Chat $chat);
+
+    /**
+     * Returns the name to display for that chat entry.
+     *
+     * @param Chat $chat
+     * @return string
+     */
+    public function getDisplayName(Chat $chat);
+
+    /**
+     * Returns the nickname of the actor for that chat entry or its hostname
+     * in case there is no nickname.
+     *
+     * @param Chat $chat
+     * @return string
+     */
+    public function getActorName(Chat $chat);
+
+    /**
+     * Transform an actor name.
+     *
+     * @param $actor
+     * @param $prefix
+     * @return string
+     */
+    public function transformActor($actor, $prefix = '');
+}

--- a/src/Korobi/WebBundle/Repository/ChannelRepository.php
+++ b/src/Korobi/WebBundle/Repository/ChannelRepository.php
@@ -30,7 +30,7 @@ class ChannelRepository extends DocumentRepository {
             ->field('network')
                 ->equals($network)
             ->field('channel')
-                ->equals(new \MongoRegex('/^' . $channel . '/i'))
+                ->equals(new \MongoRegex('/^' . preg_quote($channel, '/') . '/i'))
             ->getQuery()
             ->execute();
     }

--- a/src/Korobi/WebBundle/Resources/config/services.yml
+++ b/src/Korobi/WebBundle/Resources/config/services.yml
@@ -3,6 +3,7 @@ imports:
     - { resource: services/helpers.yml }
     - { resource: services/controllers.yml }
     - { resource: services/console.yml }
+    - { resource: services/irc_logs.yml }
 
 services:
     korobi.user_provider:

--- a/src/Korobi/WebBundle/Resources/config/services/irc_logs.yml
+++ b/src/Korobi/WebBundle/Resources/config/services/irc_logs.yml
@@ -1,0 +1,9 @@
+services:
+    korobi.irc.log_parser:
+        class: Korobi\WebBundle\Parser\LogParser
+        arguments:
+            - @translator
+    korobi.irc.render_manager:
+        class: Korobi\WebBundle\IrcLogs\RenderManager
+        arguments:
+             - @korobi.irc.log_parser

--- a/src/Korobi/WebBundle/Resources/views/controller/generic/about.html.twig
+++ b/src/Korobi/WebBundle/Resources/views/controller/generic/about.html.twig
@@ -73,15 +73,13 @@
                 <li><a href="https://jquery.com/">jQuery</a></li>
                 <li><a href="http://sass-lang.com/">SASS</a> (primarily using SCSS syntax)</li>
                 <li><a href="http://bourbon.io/">Bourbon</a>, <a href="http://bitters.bourbon.io/">Bitters</a>,
-                    <a href="http://neat.bourbon.io/">Neat</a>, <a href="http://refills.bourbon
-                    .io/">Refills</a></li>
+                    <a href="http://neat.bourbon.io/">Neat</a>, <a href="http://refills.bourbon.io/">Refills</a></li>
                 <li><a href="http://subtlepatterns.com">SubtlePatterns</a></li>
                 <li><a href="http://fortawesome.github.io/Font-Awesome/">FontAwesome</a></li>
                 <li><a href="http://prismjs.com/">PrimJS</a></li>
                 <li><a href="https://github.com/eternicode/bootstrap-datepicker">Bootstrap DatePicker</a></li>
                 <li><a href="http://unicorn-ui.com/buttons/builder/">Buttons</a></li>
-                <li><a href="http://osvaldas
-                .info/elegant-css-and-jquery-tooltip-responsive-mobile-friendly">Responsive Tooltips</a></li>
+                <li><a href="http://osvaldas.info/elegant-css-and-jquery-tooltip-responsive-mobile-friendly">Responsive Tooltips</a></li>
                 <li>Parts of <a href="http://getbootstrap.com">Bootstrap</a></li>
             </ul>
         </li>
@@ -117,7 +115,7 @@
         </li>
         <li>IRC
             <ul>
-                <li><a href="https://www.oracle.com/java/index.html">Java</a> 8</li>
+                <li><a href="https://www.oracle.com/java/index.html">Java 8</a></li>
                 <li><a href="https://github.com/KittehOrg/KittehIRCClientLib">KittehIRCClientLib</a></li>
                 <li><a href="https://github.com/google/guava">Guava</a></li>
                 <li><a href="https://commons.apache.org/proper/commons-lang/">Apache Commons Lang 3</a></li>
@@ -125,8 +123,7 @@
                 <li><a href="http://www.joda.org/joda-time/">Joda-Time</a></li>
                 <li><a href="http://www.ocpsoft.org/prettytime/">PrettyTime</a></li>
                 <li><a href="https://github.com/zml2008/configurate">Configurate</a> (using <a
-                            href="https://github.com/typesafehub/config/blob/master/HOCON
-                            .md#hocon-human-optimized-config-object-notation">HOCON</a>)</li>
+                            href="https://github.com/typesafehub/config/blob/master/HOCON.md#hocon-human-optimized-config-object-notation">HOCON</a>)</li>
                 <li><a href="https://github.com/sk89q/Intake">Intake</a></li>
                 <li><a href="http://unirest.io/java.html">Unirest for Java</a></li>
                 <li><a href="http://sparkjava.com/download.html">Spark</a></li>

--- a/src/Korobi/WebBundle/Resources/views/controller/generic/irc/channel/home.html.twig
+++ b/src/Korobi/WebBundle/Resources/views/controller/generic/irc/channel/home.html.twig
@@ -1,4 +1,5 @@
 {% extends 'KorobiWebBundle::layout.html.twig' %}
+{% import "KorobiWebBundle::macro/log_render.html.twig" as log_render %}
 
 {% set page_title = channel_name ~ ' on ' ~ network_name %}
 
@@ -6,7 +7,11 @@
     <h1>{{ channel_name }} on <a href="{{ path('network', {'network': network_slug}) }}">{{ network_name }}</a></h1>
     <h2>Topic: <em>{{ topic.value|ircformat|raw }}</em></h2>
     <h3>Topic set by: <em>{{ topic.setter_nick }}</em> on {{ topic.time }}</h3>
-    <strong>Live logs</strong>
+
+    {% if sample_logs is not empty %}
+        <strong>Live logs</strong>
+        {# {{  log_render.log_render(sample_logs, true) }} #}
+    {% endif %}
     <pre>{{ sample_logs|json_encode }}</pre>
     <strong>Command Prefix: </strong> {{ command_prefix }}<br>
     {% if channel.LastActivityValid != null %}

--- a/src/Korobi/WebBundle/Resources/views/controller/generic/irc/channel/logs.html.twig
+++ b/src/Korobi/WebBundle/Resources/views/controller/generic/irc/channel/logs.html.twig
@@ -1,4 +1,5 @@
 {% extends 'KorobiWebBundle::layout.html.twig' %}
+{% import "KorobiWebBundle::macro/log_render.html.twig" as log_render %}
 
 {% set page_title = channel_name ~ ' on ' ~ network_name ~ ' - ' ~ (is_tail ? 'Tail' : 'Logs') %}
 
@@ -57,25 +58,7 @@
         {% if logs is empty %}
             <div class="empty">Sorry, no logs are available for the requested date.</div>
         {% else %}
-            {% for line_num, line in logs %}
-                <div data-nick="{{ line.nick }}" data-event-id="{{ line.id }}" data-event-type="{{ line.type }}" class="line{% if not is_tail %} js-hl" data-line-num="{{ line_num + 1 }}{% endif %}">
-                    <span class="timestamp">
-                        {# The date is UTC, js will translate it to the correct timezone #}
-                        {{ gmdate('H:i:s', line.timestamp) }}
-                    </span>
-                    <span class="nick irc--{{ "%02d"|format(line.nickColour) }}-df
-                            {%- if line.role is not empty %} {{ line.role }}{% endif %}"
-                            {%- if line.nickTooLong %} title="{{ line.realNick }}" rel="tooltip"{% endif %}>
-                        {{- line.displayNick -}}
-                        {%- if line.nickTooLong -%}
-                            +
-                        {%- endif -%}
-                    </span>
-                    <span class="message">
-                        {{- line.message|raw -}}
-                    </span>
-                </div>
-            {% endfor %}
+            {{ log_render.log_render(logs, is_tail) }}
         {% endif %}
     </div>
 {% endblock %}

--- a/src/Korobi/WebBundle/Resources/views/macro/log_render.html.twig
+++ b/src/Korobi/WebBundle/Resources/views/macro/log_render.html.twig
@@ -1,0 +1,22 @@
+{% macro log_render(logs, is_tail) %}
+    {% for line_num, line in logs %}
+        <div data-nick="{{ line.nick }}" data-event-id="{{ line.id }}" data-event-type="{{ line.type }}"
+             class="line{% if not is_tail %} js-hl" data-line-num="{{ line_num + 1 }}{% endif %}">
+                    <span class="timestamp">
+                        {# The date is UTC, js will translate it to the correct timezone #}
+                        {{ gmdate('H:i:s', line.timestamp) }}
+                    </span>
+                    <span class="nick irc--{{ "%02d"|format(line.nickColour) }}-df
+                            {%- if line.role is not empty %} {{ line.role }}{% endif %}"
+                            {%- if line.nickTooLong %} title="{{ line.realNick }}" rel="tooltip"{% endif %}>
+                        {{- line.displayNick -}}
+                        {%- if line.nickTooLong -%}
+                            +
+                        {%- endif -%}
+                    </span>
+                    <span class="message">
+                        {{- line.message|raw -}}
+                    </span>
+        </div>
+    {% endfor %}
+{% endmacro %}

--- a/src/Korobi/WebBundle/Test/Unit/RenderManagerTest.php
+++ b/src/Korobi/WebBundle/Test/Unit/RenderManagerTest.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace Korobi\WebBundle\Test\Unit;
+
+use DateTime;
+use Korobi\WebBundle\Document\Chat;
+use Korobi\WebBundle\IrcLogs\RenderManager;
+use Korobi\WebBundle\IrcLogs\RenderSettings;
+use Korobi\WebBundle\Parser\LogParserInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class RenderManagerTest extends WebTestCase {
+
+
+    public function testRenderingIllegalNotice() {
+        $sut = new RenderManager(new ParserStub());
+        $illegalNotice = new Chat();
+        $illegalNotice->setType("MESSAGE");
+        $illegalNotice->setNotice(true);
+        $illegalNotice->setNoticeTarget("VOICE");
+        $this->assertEmpty($sut->renderLogs([$illegalNotice]));
+    }
+
+    public function testRenderingMultipleDocuments() {
+        $sut = new RenderManager(new ParserStub());
+        $chat1 = new Chat();
+        $chat1->setType("KICK");
+        $chat1->setDate(new DateTime());
+        $chat2 = new Chat();
+        $chat2->setDate(new DateTime());
+        $chat2->setType("MESSAGE");
+        $this->assertCount(2, $sut->renderLogs([$chat1, $chat2]));
+    }
+
+    public function testActualDataReturned() {
+        $sut = new RenderManager(new ParserStub());
+        $chat1 = new Chat();
+        $chat1->setType("EXOTIC");
+        $chat1->setDate(new DateTime());
+        $out = $sut->renderLogs([$chat1]);
+        $forTwig = $out[0];
+        $this->assertCount(1, $out);
+        $this->assertArrayHasKeys(['id', "timestamp", "type", "role", "nickColour", "displayNick", "realNick",
+            "nickTooLong", "nick", "message"], $forTwig);
+        $this->assertEquals($forTwig['type'], "exotic");
+        $this->assertEquals($forTwig['message'], "A message");
+    }
+
+    public function testRenderingWhitelist() {
+        $sut = new RenderManager(new ParserStub());
+        $chat1 = new Chat();
+        $chat1->setType("KICK");
+        $chat1->setDate(new DateTime());
+        $chat2 = new Chat();
+        $chat2->setDate(new DateTime());
+        $chat2->setType("MESSAGE");
+        $this->assertCount(1, $sut->renderLogs([$chat1, $chat2], ["message"]));
+    }
+
+    public function testNickChopping() {
+        $sut = new RenderManager(new ParserStub());
+        $chat1 = new Chat();
+        $chat1->setType("EXOTIC");
+        $name = str_repeat("a", RenderSettings::MAX_NICK_LENGTH + 5);
+        $chat1->setActorName($name);
+        $chat1->setDate(new DateTime());
+        $out = $sut->renderLogs([$chat1]);
+        $forTwig = $out[0];
+        $this->assertEquals($forTwig['realNick'], $name);
+        $this->assertNotEquals($forTwig['displayNick'], $name);
+        $this->assertTrue($forTwig['nickTooLong']);
+    }
+
+    /**
+     * @expectedException \Korobi\WebBundle\Exception\UnsupportedOperationException
+     */
+    public function testParsingUnparsableType() {
+        $sut = new RenderManager(new ParserStub());
+        $chat1 = new Chat();
+        $chat1->setType("CAT");
+        $chat1->setDate(new DateTime());
+        $sut->renderLogs([$chat1]);
+    }
+
+    private function assertArrayHasKeys(array $keys, array $arr) {
+        foreach ($keys as $key) {
+            $this->assertArrayHasKey($key, $arr);
+        }
+    }
+}
+
+class ParserStub implements LogParserInterface {
+
+    /**
+     * @param Chat $chat
+     * @return string
+     */
+    public function parseExotic(Chat $chat) {
+        return "A message";
+    }
+
+    /**
+     * Returns the name to display for that chat entry.
+     *
+     * @param Chat $chat
+     * @return string
+     */
+    public function getDisplayName(Chat $chat) {
+        return $this->getActorName($chat);
+    }
+
+    /**
+     * Returns the nickname of the actor for that chat entry or its hostname
+     * in case there is no nickname.
+     *
+     * @param Chat $chat
+     * @return string
+     */
+    public function getActorName(Chat $chat) {
+        return $chat->getActorName();
+    }
+
+    // --------------------------------------- //
+
+    /**
+     * @param Chat $chat
+     * @return string
+     */
+    public function parseAction(Chat $chat) {
+        // TODO: Implement parseAction() method.
+    }
+
+    /**
+     * @param Chat $chat
+     * @return string
+     */
+    public function parseJoin(Chat $chat) {
+        // TODO: Implement parseJoin() method.
+    }
+
+    /**
+     * @param Chat $chat
+     * @return string
+     */
+    public function parseKick(Chat $chat) {
+        // TODO: Implement parseKick() method.
+    }
+
+    /**
+     * @param Chat $chat
+     * @return string
+     */
+    public function parseMessage(Chat $chat) {
+        // TODO: Implement parseMessage() method.
+    }
+
+    /**
+     * @param Chat $chat
+     * @return string
+     */
+    public function parseMode(Chat $chat) {
+        // TODO: Implement parseMode() method.
+    }
+
+    /**
+     * @param Chat $chat
+     * @return string
+     */
+    public function parseNick(Chat $chat) {
+        // TODO: Implement parseNick() method.
+    }
+
+    /**
+     * @param Chat $chat
+     * @return string
+     */
+    public function parsePart(Chat $chat) {
+        // TODO: Implement parsePart() method.
+    }
+
+    /**
+     * @param Chat $chat
+     * @return string
+     */
+    public function parseQuit(Chat $chat) {
+        // TODO: Implement parseQuit() method.
+    }
+
+    /**
+     * @param Chat $chat
+     * @return string
+     */
+    public function parseTopic(Chat $chat) {
+        // TODO: Implement parseTopic() method.
+    }
+
+    /**
+     * @param Chat $chat
+     * @return string
+     */
+    public function getColourForActor(Chat $chat) {
+        // TODO: Implement getColourForActor() method.
+    }
+
+    /**
+     * Transform an actor name.
+     *
+     * @param $actor
+     * @param $prefix
+     * @return string
+     */
+    public function transformActor($actor, $prefix = '') {
+        // TODO: Implement transformActor() method.
+    }
+}

--- a/src/Korobi/WebBundle/Util/GitInfo.php
+++ b/src/Korobi/WebBundle/Util/GitInfo.php
@@ -25,7 +25,7 @@ class GitInfo {
      * @param string $environment
      */
     public function updateData($environment = 'dev') {
-        $root = __DIR__ . '/../../../../'; // bit of a hack
+        $root = __DIR__ . '/../../../../'; // just a bit of a hack
         $ref = (new \SplFileObject($root . '.git/HEAD'))->getCurrentLine();
         $ref = trim(explode(' ', $ref)[1]);
 


### PR DESCRIPTION
This PR removes some of the IRC log rendering logic from \Korobi\WebBundle\Controller\Generic\IRC\Channel\ChannelLogController and introduces a new class - \Korobi\WebBundle\IrcLogs\RenderManager. The PR changes the homepage controller to now make use of the manager class, thus removing the need to duplicate logic already in the logs controller. We'll also be able to use the same class for the live logs in the channel home controller.

Additionally, this PR makes it possible to localise all of the log-specific messages (e.g. "x joined the channel") and moves away from including this text directly in the PHP functions by introducing a localisation config file which can potentially be distributed for translation without requiring access to the codebase. The localisation file also uses a well-known standard (XLIFF) which should make it easy to use with crowd-sourced localisation sites.

Finally, we're now able to test a lot more of the log rendering logic. This PR adds 6 new test functions to the existing bank of unit tests, helping to ensure that op-notices aren't inadvertently included in logs, whitelisting and name trimming works as intended etc.
