### PR TITLE
Add meta tags to some popular pages

### DIFF
--- a/src/Korobi/WebBundle/Resources/views/controller/generic/about.html.twig
+++ b/src/Korobi/WebBundle/Resources/views/controller/generic/about.html.twig
@@ -2,6 +2,10 @@
 
 {% set page_title = 'About' %}
 
+{% block head %}
+    <meta name="description" content="The origins of the Korobi project, information on how it is built and the team behind it.">
+{% endblock head %}
+
 {% block body %}
     <h1>What is Korobi?</h1>
     <p>

--- a/src/Korobi/WebBundle/Resources/views/controller/generic/home.html.twig
+++ b/src/Korobi/WebBundle/Resources/views/controller/generic/home.html.twig
@@ -2,6 +2,10 @@
 
 {% set page_title = 'Home' %}
 
+{% block head %}
+    <meta name="description" content="Korobi is a set of tools for IRC channels, aiming to be the swiss army knife of IRC. Korobi can maintain channel logs, commands, statistics and more.">
+{% endblock head %}
+
 {% block hero %}
     <div class="hero">
         <h1>Korobi <small>Kitten powered.</small></h1>

--- a/src/Korobi/WebBundle/Resources/views/controller/generic/irc/channel/commands.html.twig
+++ b/src/Korobi/WebBundle/Resources/views/controller/generic/irc/channel/commands.html.twig
@@ -2,6 +2,10 @@
 
 {% set page_title = channel_name ~ ' on ' ~ network_name ~ ' - Commands' %}
 
+{% block head %}
+    <meta name="description" content="User-created channel commands for IRC channel {{ channel_name }} on network {{ network_name }}.">
+{% endblock head %}
+
 {% block body %}
     <h1>Commands for {{ channel_name }} on {{ network_name }}</h1>
     <div class="commands">

--- a/src/Korobi/WebBundle/Resources/views/controller/generic/irc/channel/stats.html.twig
+++ b/src/Korobi/WebBundle/Resources/views/controller/generic/irc/channel/stats.html.twig
@@ -2,6 +2,10 @@
 
 {% set page_title = channel_name ~ ' on ' ~ network_name ~ ' - Stats' %}
 
+{% block head %}
+    <meta name="description" content="Chat statistics for IRC channel {{ channel_name }} on network {{ network_name }}.">
+{% endblock head %}
+
 {% block body %}
     <h1>Stats for {{ channel_name }} on {{ network_name }}</h1>
     <div class="logs">

--- a/src/Korobi/WebBundle/Resources/views/controller/generic/irc/network/network.html.twig
+++ b/src/Korobi/WebBundle/Resources/views/controller/generic/irc/network/network.html.twig
@@ -2,6 +2,10 @@
 
 {% set page_title = network_name %}
 
+{% block head %}
+    <meta name="description" content="Channels on the {{ network_name }} IRC network.">
+{% endblock head %}
+
 {% block body %}
     <h1>{{ network_name }}</h1>
     {% if all_channels_private %}

--- a/src/Korobi/WebBundle/Resources/views/controller/generic/irc/network/networks.html.twig
+++ b/src/Korobi/WebBundle/Resources/views/controller/generic/irc/network/networks.html.twig
@@ -2,6 +2,10 @@
 
 {% set page_title = 'Networks' %}
 
+{% block head %}
+    <meta name="description" content="IRC networks which are supported by Korobi.">
+{% endblock head %}
+
 {% block body %}
     <h1>Networks</h1>
     {% if all_networks_private %}


### PR DESCRIPTION
**This PR adds meta description tags to:**
- Home page
- About page
- Channel list
- Channel stats/commands pages
- Network list

**This is useful for:**
- Search engines
- Social media sites which use the descriptions when links are posted

**Further reading:**
- https://support.google.com/webmasters/answer/35624?rd=1#1
- https://moz.com/learn/seo/meta-description
