### PR TITLE
Fix test output parser

### DIFF
--- a/src/Korobi/WebBundle/Deployment/TestOutputParser.php
+++ b/src/Korobi/WebBundle/Deployment/TestOutputParser.php
@@ -36,6 +36,7 @@ class TestOutputParser {
 
         if ($data['failures'] > 0) {
             $data['status'] = 'Fail';
+            $data['passed'] = $data['tests'] - $data['failures'];
         }
 
         if (StringUtil::stringContains($line, "OK") && $data['status'] == "Pass") {

--- a/src/Korobi/WebBundle/Test/Unit/TestOutputParserTest.php
+++ b/src/Korobi/WebBundle/Test/Unit/TestOutputParserTest.php
@@ -41,6 +41,14 @@ class TestOutputParserTest extends WebTestCase {
         $this->assertEquals('Pass', $data['status']);
     }
 
+    public function testWhenNoExplicitPassNumberWithFailures() {
+        $data = (new TestOutputParser())->parseLine('Tests: 41, Assertions: 134, Failures: 2.');
+        $this->assertEquals(41, $data['tests']);
+        $this->assertEquals(39, $data['passed']);
+        $this->assertEquals(134, $data['assertions']);
+        $this->assertEquals('Fail', $data['status']);
+    }
+
     public function testRealLifeExample() {
         $data = (new TestOutputParser())->parseLine('Tests: 25, Assertions: 61, Skipped: 4.');
         $this->assertEquals(


### PR DESCRIPTION
This increases test coverage and adds a fix based on an erroneous "0 tests passed! 2 failed." Akio message seen in #korobi.
