### PR TITLE
Attempt to fix recently active channels table on homepage

### DIFF
--- a/src/Korobi/WebBundle/Repository/ChannelRepository.php
+++ b/src/Korobi/WebBundle/Repository/ChannelRepository.php
@@ -43,7 +43,7 @@ class ChannelRepository extends DocumentRepository {
      */
     public function getRecentlyActiveChannels($limit) {
         return $this->createQueryBuilder()
-            ->sort('last_valid_content_at', 'DESC') // TODO
+            ->sort('last_activity_valid', 'DESC') // TODO
             ->field('key')
                 ->equals(null)
             ->limit($limit)


### PR DESCRIPTION
Uses new column name in sort (same column used when displaying the timestamp).
