### PR TITLE
Homepage vanity title for search engines

### DIFF
--- a/src/Korobi/WebBundle/Resources/views/controller/generic/home.html.twig
+++ b/src/Korobi/WebBundle/Resources/views/controller/generic/home.html.twig
@@ -1,7 +1,8 @@
 {% extends 'KorobiWebBundle::layout.html.twig' %}
 {% import "KorobiWebBundle::macro/log_render.html.twig" as log_render %}
 
-{% set page_title = 'Home' %}
+{% set page_title = 'Korobi: IRC logging and tools' %}
+{% set do_not_touch_title = true %}
 
 {% block head %}
     <meta name="description" content="Korobi is a set of tools for IRC channels, aiming to be the swiss army knife of IRC. Korobi can maintain channel logs, commands, statistics and more.">

--- a/src/Korobi/WebBundle/Resources/views/layout.html.twig
+++ b/src/Korobi/WebBundle/Resources/views/layout.html.twig
@@ -2,7 +2,12 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title>{% if page_title is defined %}{{ page_title }} | {% endif %}{{ app_name }}</title>
+    {% if do_not_touch_title is defined %}
+        {# if the title isn't defined, we *need* to fail #}
+        <title>{{ page_title }}</title>
+    {% else %}
+        <title>{% if page_title is defined %}{{ page_title }} | {% endif %}{{ app_name }}</title>
+    {% endif %}
     <meta name='viewport' content='initial-scale=1'>
     <link type="text/plain" rel="author" href="/humans.txt" />
     {% stylesheets filter='scss' '@KorobiWebBundle/Resources/assets/sass/application.scss' output='assets/css/application.css' %}


### PR DESCRIPTION
### The problem

Right now, users searching for Korobi in Google will see the following result:

![](https://i.imgur.com/LXp4B28.png)

The description text shown under the link is decent, but the title isn't informative. Consider the following examples of well-established mainstream sites:

![](https://i.imgur.com/WvmmBAm.png)

![](https://i.imgur.com/xdrBduk.png)

![](https://i.imgur.com/M2nKhW0.png)

![](https://i.imgur.com/ii2i6S3.png)

![](https://i.imgur.com/N97m7gK.png)

Notice how all of these results have a couple of words along with the brand name to explain what the site does/is about? This is not only important for Google, which uses title tags when indexing<sup>[[1]](https://support.google.com/webmasters/answer/70897?vid=1-635752584399186356-2527838721096450810)</sup> but also for users who want to understand what a site can provide to them before they visit.
### This PR

This PR changes the homepage's title to _Korobi: IRC logging and tools_ and adds appropriate code to the twig layout to allow pages to choose their own title if they wish (and suppress automatic suffixing with the application name).

The title I've chosen can easily be changes and I'd be interested to see if we have any better suggestions that could be used. I've mentioned logging explicitly because it's really our main feature and the thing we've probably done the most work on. We need to be careful to keep this title short (see the examples above for how many characters we can potentially use).
