### PR TITLE
Change tagline text and capitalisation changes on homepage

### DIFF
--- a/src/Korobi/WebBundle/Resources/views/controller/generic/home.html.twig
+++ b/src/Korobi/WebBundle/Resources/views/controller/generic/home.html.twig
@@ -9,8 +9,7 @@
 
 {% block hero %}
     <div class="hero">
-        <h1>Korobi <small>Kitten powered.</small></h1>
-        {# TODO: Put a decent description here for Google. #}
+        <h1>Korobi <small>IRC Swiss Army knife.</small></h1>
         <!--googleoff: all-->
         {{ log_render.log_render(messages) }}
         <!--googleon: all-->
@@ -50,7 +49,7 @@
             <h2 class="content-block-header"><i class="fa fa-info-circle"></i> About the project</h2>
             <div class="content-block-content">
                 <p>
-                    The Korobi project aims to be the swiss army knife of IRC.
+                    The Korobi project aims to be the Swiss Army knife of IRC.
                 </p>
                 <p>
                     Korobi is carefully designed by people who enjoy using IRC on a day to day basis, 


### PR DESCRIPTION
Although I do like kittens, the current tagline doesn't do a brilliant job of describing what the project and site is about.

This PR changes it to "IRC Swiss Army knife". The exact content of the tagline can be changed if anyone has any other ideas - I'm just trying to make it more accurate for users who've never visited the site before.

I've also changed some of the capitalisation in the "About the project" block since 'Swiss Army' refers to an entity.
