### PR TITLE
ES port-forwarding rules in Vagrantfile.example

### DIFF
--- a/Vagrantfile.example
+++ b/Vagrantfile.example
@@ -9,6 +9,8 @@ Vagrant.configure(2) do |config|
     config.vm.network "forwarded_port", guest: 80, host: 8080     # http
     config.vm.network "forwarded_port", guest: 443, host: 4443    # https
     config.vm.network "forwarded_port", guest: 27017, host: 27717 # mongodb
+    config.vm.network "forwarded_port", guest: 9300, host: 9301 # elasticsearch (TCP transport)
+    config.vm.network "forwarded_port", guest: 9200, host: 9201 # elasticsearch (HTTP transport)
 
     config.vm.synced_folder ".", "/vagrant", id: "vagrant-root",
         owner: "vagrant", group: "www-data", mount_options: ["dmode=775,fmode=664"]


### PR DESCRIPTION
This allows use of applications such as the MongoToElastic importer to run outside the VM where they'll probably see better performance.