### PR TITLE
Remove unnecessary requirement for trailing commas

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -16,7 +16,6 @@ return Symfony\CS\Config\Config::create()
         'parenthesis',
         'php_closing_tag',
         'visibility',
-        'multiline_array_trailing_comma',
         'namespace_no_leading_whitespace',
         'remove_lines_between_uses',
         'single_array_no_trailing_comma',
@@ -33,7 +32,7 @@ return Symfony\CS\Config\Config::create()
             ->exclude([
                 'app',
                 'web',
-                'vendor',
+                'vendor'
             ])
             ->notPath('src/Korobi/WebBundle/Resources/views/controller/generic/style_guide.html.twig')
     );


### PR DESCRIPTION
PHP manual describes this practice as "unusual", I see it as a waste of a byte and although it improves diff output in some cases, it's not supported in some languages (e.g. JS with some user agents) and it seems like a bad habit to get into. Hell, the .php_cs file itself didn't obey this rule. Also note that the following is invalid JSON:

```json
["test","test1",]
```

Worth noting R# will flag up these sorts of redundant characters with an inspection and offer to remove them.

This is a discussion PR more than anything else.