### PR TITLE
Separate tests into suites

### DIFF
--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -8,10 +8,13 @@
          bootstrap="bootstrap.php.cache"
 >
     <testsuites>
-        <testsuite name="Project Test Suite">
-            <directory>../src/*/*Bundle/Test</directory>
-            <directory>../src/*/Bundle/*Bundle/Test</directory>
-            <directory>../src/*Bundle/Test</directory>
+        <testsuite name="Project UnitTest Suite">
+            <directory>../src/Korobi/WebBundle/Test/Unit</directory>
+        </testsuite>
+        <testsuite name="All other tests">
+            <directory>../src/Korobi/WebBundle/Test/Command</directory>
+            <directory>../src/Korobi/WebBundle/Test/Controller</directory>
+            <directory>../src/Korobi/WebBundle/Test/Integration</directory>
         </testsuite>
     </testsuites>
 


### PR DESCRIPTION
This PR allows tests to be filtered to allow unit tests on their own to be run in environments where services such as ElasticSearch and MongoDB are unavailable. In these environments it often doesn't make sense to try and run some of the functional tests.

**Example command (to be invoked in the `app/` directory):**

`phpunit --testsuite "Project UnitTest Suite"`

On its own, `phpunit` will function just as before and run all testsuites.