### PR TITLE
Support Windows and support for skipping provisioning

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ provisioning = {
   # happen; this is useful it you find yourself using `vagrant destroy -f;
   # vagrant up` very often, or if you're on Windows, which doesn't support
   # Ansible
-  enabled: true,
+  enabled: ENV.fetch('KOROBI_PROVISIONING', 'true') == 'true',
 
   # if true, Ansible's verbose mode (level 'vv') will be used; does nothing if
   # provisioning is disabled

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,27 +1,48 @@
-debug = true
+# options for Vagrant provisioning; do NOT commit personal changes to these
+provisioning = {
+
+  # if enabled, the base Ubuntu box will be used and Ansible will provision it;
+  # when disabled, the custom Korobi box will be used and no provisioning will
+  # happen; this is useful it you find yourself using `vagrant destroy -f;
+  # vagrant up` very often, or if you're on Windows, which doesn't support
+  # Ansible
+  enabled: true,
+
+  # if true, Ansible's verbose mode (level 'vv') will be used; does nothing if
+  # provisioning is disabled
+  debug: false
+  
+}
 
 Vagrant.configure(2) do |config|
+  if provisioning[:enabled]
     config.vm.box = 'ubuntu/trusty64'
-    config.vm.hostname = 'korobi'
+  else
+    config.vm.box = 'bionicrm/korobi-web'
+  end
 
-    config.vm.network :private_network, ip: '10.0.5.6'
+  config.vm.hostname = 'korobi'
 
-    config.vm.synced_folder '.', '/home/vagrant/site',
-      id: 'vagrant-root',
-      owner: 'vagrant',
-      group: 'www-data',
-      mount_options: ['dmode=775,fmode=664']
+  config.vm.network :private_network, ip: '10.0.5.6'
 
-    config.vm.provider :virtualbox do |v|
-      v.name = 'korobi_web_vagrant'
-      v.memory = 1024
-    end
+  config.vm.synced_folder '.', '/home/vagrant/site',
+    id: 'vagrant-root',
+    owner: 'vagrant',
+    group: 'www-data',
+    mount_options: ['dmode=775,fmode=664']
 
+  config.vm.provider :virtualbox do |v|
+    v.name = 'korobi_web_vagrant'
+    v.memory = 1024
+  end
+
+  if provisioning[:enabled]
     config.vm.provision :ansible do |ansible|
-      if debug
+      if provisioning[:debug]
         ansible.verbose = 'vv'
       end
 
       ansible.playbook = 'playbook.yml'
     end
+  end
 end

--- a/roles/server/tasks/symfony.yml
+++ b/roles/server/tasks/symfony.yml
@@ -27,9 +27,13 @@
 
 - name: install NPM packages for Symfony project
   npm:
+    name={{ item.name }}
+    version={{ item.version }}
     path="{{ home }}/site"
     state=present
     global=yes
+  with_items:
+    - { name: uglify-js, version: ^2.4.24 }
 
 - name: check for Korobi database
   command: echo "show dbs" | mongo

--- a/roles/server/tasks/symfony.yml
+++ b/roles/server/tasks/symfony.yml
@@ -27,13 +27,9 @@
 
 - name: install NPM packages for Symfony project
   npm:
-    name={{ item.name }}
-    version={{ item.version }}
     path="{{ home }}/site"
     state=present
     global=yes
-  with_items:
-    - { name: uglify-js, version: ^2.4.24 }
 
 - name: check for Korobi database
   command: echo "show dbs" | mongo


### PR DESCRIPTION
Vagrant breaks for Windows users because of Ansible not supporting the OS, which is used for provisioning. If configured, the box on Atlas will be downloaded and used (without provisioning) so that Windows users and anyone who often uses `vagrant destroy -f; vagrant up` can skip the provisioning process.

Skipping the provisioning process really only means that changes to the Ansible roles will not be used right away. However, these updates should simply be packaged in a box and uploaded to Atlas, and then the latest updates will be downloaded by the user with `vagrant box update`.

~~Additionally, the sort-of unrelated commit regarding NPM is necessary because it seems to sometimes run out of memory if it needs to download packages again. The new task just provides it the packages it needs to install instead of reading from packages.json. This is *probably* a flaw in NPM.~~