### PR TITLE
Fix broken deployment GitInfo call

### DIFF
--- a/src/Korobi/WebBundle/Controller/Internal/DeploymentController.php
+++ b/src/Korobi/WebBundle/Controller/Internal/DeploymentController.php
@@ -66,7 +66,7 @@ class DeploymentController extends BaseController {
     public function deployAction(Request $request) {
         /** @var \Korobi\WebBundle\Document\User $user */
         $user = $this->getUser();
-        $env = $this->getParameter("kernel.environment");
+        $env = $this->getParameter('kernel.environment');
         $info = new DeploymentInfo($request, new Revision(), $user, $this->authChecker, $this->hmacKey, $this->rootPath, $env);
         $processor = new DeploymentProcessor($info, $this->logger, $this->container->get('kernel'), $this->akio,
             $this->get('doctrine_mongodb')->getManager(), $this->get("korobi.git_info"));

--- a/src/Korobi/WebBundle/Controller/Internal/DeploymentController.php
+++ b/src/Korobi/WebBundle/Controller/Internal/DeploymentController.php
@@ -66,8 +66,8 @@ class DeploymentController extends BaseController {
     public function deployAction(Request $request) {
         /** @var \Korobi\WebBundle\Document\User $user */
         $user = $this->getUser();
-
-        $info = new DeploymentInfo($request, new Revision(), $user, $this->authChecker, $this->hmacKey, $this->rootPath);
+        $env = $this->getParameter("kernel.environment");
+        $info = new DeploymentInfo($request, new Revision(), $user, $this->authChecker, $this->hmacKey, $this->rootPath, $env);
         $processor = new DeploymentProcessor($info, $this->logger, $this->container->get('kernel'), $this->akio,
             $this->get('doctrine_mongodb')->getManager(), $this->get("korobi.git_info"));
         $status = $processor->performDeployment();

--- a/src/Korobi/WebBundle/Deployment/DeploymentInfo.php
+++ b/src/Korobi/WebBundle/Deployment/DeploymentInfo.php
@@ -55,6 +55,11 @@ class DeploymentInfo {
     protected $messageQueue = [];
 
     /**
+     * @var string Environment name
+     */
+    protected $env;
+
+    /**
      * @param $request Request
      * @param $revision Revision
      * @param $user User
@@ -62,7 +67,7 @@ class DeploymentInfo {
      * @param $hmacKey string The HMAC key
      * @param $rootPath
      */
-    public function __construct(Request $request, Revision $revision, $user, AuthorizationChecker $authorisationChecker, $hmacKey, $rootPath) {
+    public function __construct(Request $request, Revision $revision, $user, AuthorizationChecker $authorisationChecker, $hmacKey, $rootPath, $env) {
         $this->request = $request;
         $this->revision = $revision;
         $this->user = $user;
@@ -70,6 +75,7 @@ class DeploymentInfo {
         $this->hmacKey = $hmacKey;
         $this->rootPath = $rootPath;
         $this->status = [];
+        $this->env = $env;
     }
 
     /**
@@ -135,5 +141,12 @@ class DeploymentInfo {
      */
     public function getAllMessagesInQueue() {
         return $this->messageQueue;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEnvironment() {
+        return $this->env;
     }
 }

--- a/src/Korobi/WebBundle/Deployment/Processor/PerformDeployment.php
+++ b/src/Korobi/WebBundle/Deployment/Processor/PerformDeployment.php
@@ -36,7 +36,7 @@ class PerformDeployment extends BaseProcessor implements DeploymentProcessorInte
         $info->getRevision()->setDeployOutput(implode("\n", $execOutput));
 
         // get latest git info
-        $gitInfo->updateData($info->getRootPath());
+        $gitInfo->updateData($info->getRootPath(), $info->getEnvironment());
         $info->getRevision()->setNewCommit($gitInfo->getHash());
         $info->getRevision()->setBranch($gitInfo->getBranch());
         return parent::handle($info);


### PR DESCRIPTION
In a previous PR, the updateData signature was changed to include the environment, used for checking to see if capifony is in use. The call from inside the deployment CoR classes was not updated. This PR fixes this issue by supplying the environment to the updateData function.